### PR TITLE
fix(schema): quoting to prevent values be passed as integer

### DIFF
--- a/scripts/bash/set-release.sh
+++ b/scripts/bash/set-release.sh
@@ -5,6 +5,6 @@ export SHORT_COMMIT="$2"
 export TAG_NAME="$3"
 export FILE="$4"
 
-sed -i "s|targetRevision:.*|targetRevision: ${TARGET_REVISION}|g" ${FILE}
-sed -i "s|shortCommit:.*|shortCommit: ${SHORT_COMMIT}|g" ${FILE}
-sed -i "s|tag:\s.*|tag: ${TAG_NAME}|g" ${FILE}
+sed -i "s|targetRevision:.*|targetRevision: \"${TARGET_REVISION}\"|g" ${FILE}
+sed -i "s|shortCommit:.*|shortCommit: \"${SHORT_COMMIT}\"|g" ${FILE}
+sed -i "s|tag:\s.*|tag: \"${TAG_NAME}\"|g" ${FILE}


### PR DESCRIPTION
## Problem

commit is a hexadecimal number, shortCommit sometimes can be treated as decimal and casted as integer, giving this error.
```
shortCommit: Invalid type. Expected: string, given: integer
```

## How to replicate the error?
edit some env/**/myapp.yaml and change:
```yaml
..
shortCommit: 12345
..
```

## Solution

to prevent it you can: 
1. accept integers in `shortCommit` using `anyOf` in values.schema.json, accepting integer or string.
2. quote the commit value with sed.

for me the solution 2, is right solution because `annotations` and `labels` only accept string, and my commit is about the solution 2.